### PR TITLE
Persistence v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 package-lock.json
+data/default-stack.json

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+# data folder contains files storage of stack data

--- a/stack-api/api-definition.js
+++ b/stack-api/api-definition.js
@@ -1,13 +1,11 @@
 var express = require("express");
 var Stack = require("./stack");
-
 var apiDefinitions = express.Router();
 
 apiDefinitions.get("/push/:data", function (req, res) {
-    // sample uuid -> 5b1be952-52af-409c-ad1b-645e7d2ec500
-    let uuidFromReq = '5b1be952-52af-409c-ad1b-645e7d2ec500';
     var inputData = req.params.data;
-    let stack = Stack.getStack(uuidFromReq);
+    var stackId = req.params.stackId;
+    let stack = new Stack(stackId);
     stack.on('push', (e) => {
         console.log('push event', e);
     })
@@ -16,8 +14,8 @@ apiDefinitions.get("/push/:data", function (req, res) {
 });
 
 apiDefinitions.get("/pop", function (req, res) {
-    let uuidFromReq = '5b1be952-52af-409c-ad1b-645e7d2ec500';
-    let stack = Stack.getStack(uuidFromReq);
+    var stackId = req.params.stackId;
+    let stack = new Stack(stackId);
     stack.on('pop', (e) => {
         console.log('pop event', e);
     });
@@ -29,8 +27,8 @@ apiDefinitions.get("/pop", function (req, res) {
 });
 
 apiDefinitions.get("/serialize", function (req, res) {
-    let uuidFromReq = '5b1be952-52af-409c-ad1b-645e7d2ec500';
-    let stack = Stack.getStack(uuidFromReq);
+    var stackId = req.params.stackId;
+    let stack = new Stack(stackId);
     var stackData = stack.toString();
     res.send(stackData);
 });

--- a/stack-api/filestorage.js
+++ b/stack-api/filestorage.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path')
+const baseStorageFolder = 'data';
+
+module.exports.synchronize = function (stackJson, stackId) { 
+    var json = JSON.stringify(stackJson);
+    console.log('persist stack with id '+stackId+' to file. data : '+json);
+    fs.writeFileSync(baseStorageFolder+path.sep+stackId+'.json',json);
+}
+
+module.exports.load = function (stackId) { 
+    if (fs.existsSync(baseStorageFolder+path.sep+stackId+'.json')) {
+        let rawdata = fs.readFileSync(baseStorageFolder+path.sep+stackId+'.json', 'utf8');
+        let obj = JSON.parse(rawdata);
+        return obj;
+    }else{
+        let obj = [];
+        return obj;
+    }    
+}
+


### PR DESCRIPTION
I was about to raise a pull request for my persistence code and realized same was already done by @pheenomenon .
Had missed his mention.

Anyways merged our code and raising a pull request.
following are some changes compared to @pheenomenon code.
- extracted module for storage, so we can plug another storage provider later.
- saved each stack to a separate file (this was just my preference, instead of multiple stacks in same file)
- removed hard-coding for uuid - once the UI starts passing a stack Id, no changes will be required at backend.

Please review and merge PR if this version seems an improvement.

Note  -  I have used path.sep to make sure my file handling code works across OS.
Entire flow is working for me on linux, but I don't have a windows machine to verify.
If you face any unexpected behavior this might be the culprit, please let me know in that case.
